### PR TITLE
Better image loader options for Volto defaults for source sets (#5)

### DIFF
--- a/news/5.feature
+++ b/news/5.feature
@@ -1,0 +1,1 @@
+Better image loader options for Volto defaults for source sets

--- a/src/components/ImageLoader/Img.test.jsx
+++ b/src/components/ImageLoader/Img.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { create, act } from 'react-test-renderer';
-import Img from './Img';
+import { ImgForTesting as Img } from './Img';
 import { describeAnyLoader, expectWrapper } from './AnyLoader.test';
 import config from '@plone/volto/registry';
 import makeSrcSet from './makeSrcSet';

--- a/src/components/ImageLoader/makeSrcSet.jsx
+++ b/src/components/ImageLoader/makeSrcSet.jsx
@@ -1,6 +1,6 @@
 const config = require('@plone/volto/registry').default;
 
-const makeSrcSet = (options) => {
+const makeSrcSet = (options, defaultOptions = undefined) => {
   if (options && options.hasOwnProperty('fromProps')) {
     // If already a cooked object - just use it.
     options = options.options;
@@ -18,6 +18,8 @@ const makeSrcSet = (options) => {
         }),
         createMissingScaleSrc: (src, scaleName) =>
           `${src}/@@images/image/${scaleName}`,
+        createNoDefaultScaleSrc: (src) => undefined,
+        getScalesFromProps: ({ src, scales }) => scales,
         minWidth: 0,
         maxWidth: Infinity,
         scales: {
@@ -35,6 +37,7 @@ const makeSrcSet = (options) => {
           huge: 1600,
         },
       },
+      defaultOptions,
       config.settings.srcSetOptions,
       options,
     );
@@ -48,18 +51,22 @@ const makeSrcSet = (options) => {
         preprocessSrc,
         createScaledSrc,
         createMissingScaleSrc,
+        createNoDefaultScaleSrc,
+        getScalesFromProps,
       } = this.options;
       const result = {};
       if (enabled && isLocal(src)) {
-        src = preprocessSrc(src);
         if (scales) {
           result.scales = undefined;
-        } else {
+        }
+        scales = getScalesFromProps({ src, scales });
+        if (!scales) {
           scales = this.options.scales;
         }
         if (typeof scales !== 'object') {
           throw new Error('The scales option and property must be an object');
         }
+        src = preprocessSrc(src);
         let scaledSrcList = Object.keys(scales).map((scaleName) =>
           createScaledSrc(src, scaleName, scales[scaleName]),
         );
@@ -84,6 +91,12 @@ const makeSrcSet = (options) => {
             result.src = createMissingScaleSrc(src, defaultScale);
           }
           result.defaultScale = undefined;
+        } else {
+          // No default scale?
+          const newSrc = createNoDefaultScaleSrc(src);
+          if (newSrc !== undefined) {
+            result.src = newSrc;
+          }
         }
       } else {
         // remove special properties in all cases

--- a/src/components/ImageLoader/srcSetDefaultOptionsVolto.jsx
+++ b/src/components/ImageLoader/srcSetDefaultOptionsVolto.jsx
@@ -1,8 +1,9 @@
 import { isInternalURL, flattenToAppURL } from '@plone/volto/helpers';
 
 // Acquire server data for a block
+const blockDataSrcGet = (src) => src?.image_scales?.[src?.image_field]?.[0];
 export const blockDataSrc = {
-  test: (src) => typeof src?.image_scales?.image?.[0]?.scales === 'object',
+  test: (src) => typeof blockDataSrcGet(src)?.scales === 'object',
   isLocal: (src) => isInternalURL(src.url),
   preprocessSrc: (src) => ({
     ...src,
@@ -12,13 +13,13 @@ export const blockDataSrc = {
       ),
     },
   }),
-  getScalesFromProps: ({ src, scales }) => src.image_scales.image[0].scales,
+  getScalesFromProps: ({ src, scales }) => blockDataSrcGet(src).scales,
   createScaledSrc: (src, scaleName, scaleData) => ({
     url: `${src.__cache.prefix}/${scaleData.download}`,
     width: scaleData.width,
   }),
   createNoDefaultScaleSrc: (src) =>
-    flattenToAppURL(`${src.url}/${src.image_scales.image[0].download}`),
+    flattenToAppURL(`${src.url}/${blockDataSrcGet(src).download}`),
 };
 
 // Acquire server data for an image instance

--- a/src/components/ImageLoader/srcSetDefaultOptionsVolto.jsx
+++ b/src/components/ImageLoader/srcSetDefaultOptionsVolto.jsx
@@ -1,0 +1,87 @@
+import { isInternalURL, flattenToAppURL } from '@plone/volto/helpers';
+
+// Acquire server data for a block
+export const blockDataSrc = {
+  test: (src) => typeof src?.image_scales?.image?.[0]?.scales === 'object',
+  isLocal: (src) => isInternalURL(src.url),
+  preprocessSrc: (src) => ({
+    ...src,
+    __cache: {
+      prefix: flattenToAppURL(
+        src.url.replace(/\/@@images\/image.*$/, '').replace(/\/$/, ''),
+      ),
+    },
+  }),
+  getScalesFromProps: ({ src, scales }) => src.image_scales.image[0].scales,
+  createScaledSrc: (src, scaleName, scaleData) => ({
+    url: `${src.__cache.prefix}/${scaleData.download}`,
+    width: scaleData.width,
+  }),
+  createNoDefaultScaleSrc: (src) =>
+    flattenToAppURL(`${src.url}/${src.image_scales.image[0].download}`),
+};
+
+// Acquire server data for an image instance
+export const contentDataSrc = {
+  test: (src) => typeof src?.scales === 'object',
+  isLocal: (src) => isInternalURL(src.download),
+  preprocessSrc: (src) => src,
+  getScalesFromProps: ({ src, scales }) => src.scales,
+  createScaledSrc: (src, scaleName, scaleData) => ({
+    // Important: this MUST be flattened, because it does not pass through
+    // preprocessSrc.
+    url: flattenToAppURL(scaleData.download),
+    width: scaleData.width,
+  }),
+  createNoDefaultScaleSrc: (src) => flattenToAppURL(src.download),
+};
+
+// Work without server data from statically defined scales
+export const stringSrc = {
+  test: (src) => typeof src === 'string',
+  isLocal: (src) => isInternalURL(src),
+  getScalesFromProps: ({ src, scales }) => scales,
+  preprocessSrc: (src) =>
+    flattenToAppURL(src.replace(/\/@@images\/image.*$/, '').replace(/\/$/, '')),
+  createScaledSrc: (src, scaleName, scaleData) => ({
+    url: `${src}/@@images/image/${scaleName}`,
+    width: scaleData,
+  }),
+  createNoDefaultScaleSrc: (src) => undefined,
+};
+
+// Fallback when no data is available (e.g. loading transition)
+export const missingSrc = {
+  test: (src) => true,
+  isLocal: (scr) => false,
+  preprocessSrc: (src) => undefined,
+  getScalesFromProps: ({ src, scales }) => scales,
+  createScaledSrc: (src, scaleName, scaleData) => ({}),
+  createNoDefaultScaleSrc: (src) => undefined,
+};
+
+const getProcessor = (src) =>
+  blockDataSrc.test(src)
+    ? blockDataSrc
+    : contentDataSrc.test(src)
+    ? contentDataSrc
+    : stringSrc.test(src)
+    ? stringSrc
+    : missingSrc;
+
+const srcSetDefaultOptionsVolto = {
+  // enabled: true,
+  isLocal: (src) => getProcessor(src).isLocal(src),
+  preprocessSrc: (src) => getProcessor(src).preprocessSrc(src),
+  getScalesFromProps: ({ src, scales }) =>
+    getProcessor(src).getScalesFromProps({ src, scales }),
+  createScaledSrc: (src, scaleName, scaleData) =>
+    getProcessor(src).createScaledSrc(src, scaleName, scaleData),
+  createNoDefaultScaleSrc: (src) =>
+    getProcessor(src).createNoDefaultScaleSrc(src),
+  minWidth: 0,
+  maxWidth: Infinity,
+  scales: {},
+};
+
+export default srcSetDefaultOptionsVolto;

--- a/src/components/ImageLoader/srcSetDefaultOptionsVolto.jsx
+++ b/src/components/ImageLoader/srcSetDefaultOptionsVolto.jsx
@@ -1,7 +1,8 @@
 import { isInternalURL, flattenToAppURL } from '@plone/volto/helpers';
 
 // Acquire server data for a block
-const blockDataSrcGet = (src) => src?.image_scales?.[src?.image_field]?.[0];
+const blockDataSrcGet = (src) =>
+  src?.image_scales?.[src?.image_field || 'image']?.[0];
 const blockDataPrefixGet = (src) => src?.url || src?.['@id'];
 export const blockDataSrc = {
   test: (src) => typeof blockDataSrcGet(src)?.scales === 'object',

--- a/src/components/ImageLoader/srcSetDefaultOptionsVolto.jsx
+++ b/src/components/ImageLoader/srcSetDefaultOptionsVolto.jsx
@@ -1,9 +1,11 @@
 import { isInternalURL, flattenToAppURL } from '@plone/volto/helpers';
 
 // Acquire server data for a block
-const blockDataSrcGet = (src) => src?.image_scales?.[src?.image_field]?.[0];
+const blockDataSrcGet = (src) =>
+  src?.image_scales?.[src?.image_scales?.image_field]?.[0];
+//
 export const blockDataSrc = {
-  test: (src) => typeof blockDataSrcGet(src)?.scales === 'object',
+  test: (src) => typeof blockDataSrcGet(src).scales === 'object',
   isLocal: (src) => isInternalURL(src.url),
   preprocessSrc: (src) => ({
     ...src,

--- a/src/components/ImageLoader/srcSetDefaultOptionsVolto.jsx
+++ b/src/components/ImageLoader/srcSetDefaultOptionsVolto.jsx
@@ -1,17 +1,18 @@
 import { isInternalURL, flattenToAppURL } from '@plone/volto/helpers';
 
 // Acquire server data for a block
-const blockDataSrcGet = (src) =>
-  src?.image_scales?.[src?.image_scales?.image_field]?.[0];
-//
+const blockDataSrcGet = (src) => src?.image_scales?.[src?.image_field]?.[0];
+const blockDataPrefixGet = (src) => src?.url || src?.['@id'];
 export const blockDataSrc = {
-  test: (src) => typeof blockDataSrcGet(src).scales === 'object',
-  isLocal: (src) => isInternalURL(src.url),
+  test: (src) => typeof blockDataSrcGet(src)?.scales === 'object',
+  isLocal: (src) => isInternalURL(blockDataPrefixGet(src)),
   preprocessSrc: (src) => ({
     ...src,
     __cache: {
       prefix: flattenToAppURL(
-        src.url.replace(/\/@@images\/image.*$/, '').replace(/\/$/, ''),
+        blockDataPrefixGet(src)
+          .replace(/\/@@images\/image.*$/, '')
+          .replace(/\/$/, ''),
       ),
     },
   }),
@@ -21,7 +22,9 @@ export const blockDataSrc = {
     width: scaleData.width,
   }),
   createNoDefaultScaleSrc: (src) =>
-    flattenToAppURL(`${src.url}/${blockDataSrcGet(src).download}`),
+    flattenToAppURL(
+      `${blockDataPrefixGet(src)}/${blockDataSrcGet(src).download}`,
+    ),
 };
 
 // Acquire server data for an image instance

--- a/src/components/ImageLoader/srcSetDefaultOptionsVolto.test.jsx
+++ b/src/components/ImageLoader/srcSetDefaultOptionsVolto.test.jsx
@@ -22,6 +22,9 @@ describe('srcSetDefaultOptionsVolto', () => {
       expect(processors.blockDataSrc.test(testData.blockDataSample1)).toEqual(
         true,
       );
+      expect(processors.blockDataSrc.test(testData.blockDataSample4)).toEqual(
+        true,
+      );
     });
     test('isLocal', () => {
       expect(srcSetDefaultOptionsVolto.isLocal(testData.blockDataSample1)).toBe(
@@ -33,6 +36,9 @@ describe('srcSetDefaultOptionsVolto', () => {
       expect(srcSetDefaultOptionsVolto.isLocal(testData.blockDataSample3)).toBe(
         true,
       );
+      expect(srcSetDefaultOptionsVolto.isLocal(testData.blockDataSample4)).toBe(
+        true,
+      );
       expect(
         processors.blockDataSrc.isLocal({ url: 'http://foo.bar/image.png' }),
       ).toBe(false);
@@ -42,6 +48,14 @@ describe('srcSetDefaultOptionsVolto', () => {
         srcSetDefaultOptionsVolto.preprocessSrc(testData.blockDataSample1),
       ).toEqual({
         ...testData.blockDataSample1,
+        __cache: {
+          prefix: '/example/image-2',
+        },
+      });
+      expect(
+        srcSetDefaultOptionsVolto.preprocessSrc(testData.blockDataSample4),
+      ).toEqual({
+        ...testData.blockDataSample4,
         __cache: {
           prefix: '/example/image-2',
         },
@@ -150,6 +164,53 @@ describe('srcSetDefaultOptionsVolto', () => {
           width: 64,
         },
       });
+      expect(
+        srcSetDefaultOptionsVolto.getScalesFromProps({
+          src: testData.blockDataSample4,
+          scales: 'ANYTHING',
+        }),
+      ).toEqual({
+        icon: {
+          download: '@@images/image-32-d5575b5e0795407436104a16e18ebd41.jpeg',
+          height: 17,
+          width: 32,
+        },
+        large: {
+          download: '@@images/image-800-9c8a61153197fca732c86aa1f2091cb3.jpeg',
+          height: 449,
+          width: 800,
+        },
+        larger: {
+          download: '@@images/image-1000-36afc44f7c991c35735f3338e76bc0a7.jpeg',
+          height: 562,
+          width: 1000,
+        },
+        mini: {
+          download: '@@images/image-200-6f2dd5c028b4fbf2c975d98f42077678.jpeg',
+          height: 112,
+          width: 200,
+        },
+        preview: {
+          download: '@@images/image-400-4abbad67754c69a7af7a1b91d78e680e.jpeg',
+          height: 224,
+          width: 400,
+        },
+        teaser: {
+          download: '@@images/image-600-705867124c8790a0fc7d4c799e506c2e.jpeg',
+          height: 337,
+          width: 600,
+        },
+        thumb: {
+          download: '@@images/image-128-eebe3707668d4cd3752626c026191ca0.jpeg',
+          height: 71,
+          width: 128,
+        },
+        tile: {
+          download: '@@images/image-64-0ea29ecf0ed3720e590d849dcbda5834.jpeg',
+          height: 35,
+          width: 64,
+        },
+      });
     });
     describe('createScaledSrc', () => {
       const testCreateScaledSrc = (blockDataSample, result) => () => {
@@ -201,6 +262,13 @@ describe('srcSetDefaultOptionsVolto', () => {
         ),
       ).toBe(
         '/example/teaser-block/image/@@images/preview_image-1126-1a01db87b603934db947bb1d72a06ed8.jpeg',
+      );
+      expect(
+        srcSetDefaultOptionsVolto.createNoDefaultScaleSrc(
+          testData.blockDataSample4,
+        ),
+      ).toBe(
+        '/example/image-2/@@images/image-1126-7bb80db0a452739fa96a97d3c6517495.jpeg',
       );
     });
   });

--- a/src/components/ImageLoader/srcSetDefaultOptionsVolto.test.jsx
+++ b/src/components/ImageLoader/srcSetDefaultOptionsVolto.test.jsx
@@ -1,0 +1,332 @@
+import srcSetDefaultOptionsVolto from './srcSetDefaultOptionsVolto';
+import * as processors from './srcSetDefaultOptionsVolto';
+import * as testData from './test-data';
+
+jest.mock('@plone/volto/helpers', () => {
+  const original = jest.requireActual('@plone/volto/helpers');
+  return {
+    __esModule: true,
+    flattenToAppURL: jest.fn((url) =>
+      url.replace(/http:\/\/localhost:3000/, ''),
+    ),
+    isInternalURL: jest.fn(
+      (url) =>
+        url.search(/http:\/\/localhost:3000/) !== -1 ||
+        url.search(/http:\/\//) === -1,
+    ),
+  };
+});
+
+describe('srcSetDefaultOptionsVolto', () => {
+  describe('blockDataSrc', () => {
+    test('test', () => {
+      expect(processors.blockDataSrc.test(testData.blockDataSample1)).toEqual(
+        true,
+      );
+    });
+    test('isLocal', () => {
+      expect(srcSetDefaultOptionsVolto.isLocal(testData.blockDataSample1)).toBe(
+        true,
+      );
+      expect(srcSetDefaultOptionsVolto.isLocal(testData.blockDataSample2)).toBe(
+        true,
+      );
+      expect(
+        processors.blockDataSrc.isLocal({ url: 'http://foo.bar/image.png' }),
+      ).toBe(false);
+    });
+    test('preprocessSrc', () => {
+      expect(
+        srcSetDefaultOptionsVolto.preprocessSrc(testData.blockDataSample1),
+      ).toEqual({
+        ...testData.blockDataSample1,
+        __cache: {
+          prefix: '/example/image-2',
+        },
+      });
+    });
+    test('getScalesFromProps', () => {
+      expect(
+        srcSetDefaultOptionsVolto.getScalesFromProps({
+          src: testData.blockDataSample1,
+          scales: 'ANYTHING',
+        }),
+      ).toEqual({
+        icon: {
+          download: '@@images/image-32-d5575b5e0795407436104a16e18ebd41.jpeg',
+          height: 17,
+          width: 32,
+        },
+        large: {
+          download: '@@images/image-800-9c8a61153197fca732c86aa1f2091cb3.jpeg',
+          height: 449,
+          width: 800,
+        },
+        larger: {
+          download: '@@images/image-1000-36afc44f7c991c35735f3338e76bc0a7.jpeg',
+          height: 562,
+          width: 1000,
+        },
+        mini: {
+          download: '@@images/image-200-6f2dd5c028b4fbf2c975d98f42077678.jpeg',
+          height: 112,
+          width: 200,
+        },
+        preview: {
+          download: '@@images/image-400-4abbad67754c69a7af7a1b91d78e680e.jpeg',
+          height: 224,
+          width: 400,
+        },
+        teaser: {
+          download: '@@images/image-600-705867124c8790a0fc7d4c799e506c2e.jpeg',
+          height: 337,
+          width: 600,
+        },
+        thumb: {
+          download: '@@images/image-128-eebe3707668d4cd3752626c026191ca0.jpeg',
+          height: 71,
+          width: 128,
+        },
+        tile: {
+          download: '@@images/image-64-0ea29ecf0ed3720e590d849dcbda5834.jpeg',
+          height: 35,
+          width: 64,
+        },
+      });
+    });
+    describe('createScaledSrc', () => {
+      const testCreateScaledSrc = (blockDataSample, result) => () => {
+        expect(
+          srcSetDefaultOptionsVolto.createScaledSrc(
+            srcSetDefaultOptionsVolto.preprocessSrc(blockDataSample),
+            'large',
+            blockDataSample.image_scales.image[0].scales.large,
+          ),
+        ).toEqual(result);
+      };
+      test(
+        'blockDataSample1',
+        testCreateScaledSrc(testData.blockDataSample1, {
+          url:
+            '/example/image-2/@@images/image-800-9c8a61153197fca732c86aa1f2091cb3.jpeg',
+          width: 800,
+        }),
+      );
+      test(
+        'blockDataSample2 flattening',
+        testCreateScaledSrc(testData.blockDataSample2, {
+          url:
+            '/example/image-2/@@images/image-800-9c8a61153197fca732c86aa1f2091cb3.jpeg',
+          width: 800,
+        }),
+      );
+    });
+    test('createNoDefaultScaleSrc', () => {
+      expect(
+        srcSetDefaultOptionsVolto.createNoDefaultScaleSrc(
+          testData.blockDataSample1,
+        ),
+      ).toBe(
+        '/example/image-2/@@images/image-1126-7bb80db0a452739fa96a97d3c6517495.jpeg',
+      );
+    });
+  });
+  describe('contentDataSrc', () => {
+    test('test', () => {
+      expect(processors.blockDataSrc.test(testData.contentDataSample1)).toEqual(
+        false,
+      );
+      expect(
+        processors.contentDataSrc.test(testData.contentDataSample1),
+      ).toEqual(true);
+    });
+    test('isLocal', () => {
+      expect(
+        srcSetDefaultOptionsVolto.isLocal(testData.contentDataSample1),
+      ).toBe(true);
+      expect(
+        processors.contentDataSrc.isLocal({
+          download: 'http://foo.bar/image.png',
+        }),
+      ).toBe(false);
+    });
+    test('preprocessSrc', () => {
+      expect(
+        srcSetDefaultOptionsVolto.preprocessSrc(testData.contentDataSample1),
+      ).toBe(testData.contentDataSample1);
+    });
+    test('getScalesFromProps', () => {
+      expect(
+        srcSetDefaultOptionsVolto.getScalesFromProps({
+          src: testData.contentDataSample1,
+          scales: 'ANYTHING',
+        }),
+      ).toEqual({
+        great: {
+          download:
+            'http://localhost:3000/images/plone-foundation.png/@@images/image-1200-79d8298ba97bbcac8957f2313a4f8739.png',
+          height: 263,
+          width: 1200,
+        },
+        huge: {
+          download:
+            'http://localhost:3000/images/plone-foundation.png/@@images/image-1600-36844277b711713c66c7c77f6eafa2bf.png',
+          height: 351,
+          width: 1600,
+        },
+        icon: {
+          download:
+            'http://localhost:3000/images/plone-foundation.png/@@images/image-32-471419cba465f6bf008e71a2a6597a40.png',
+          height: 7,
+          width: 32,
+        },
+        large: {
+          download:
+            'http://localhost:3000/images/plone-foundation.png/@@images/image-800-00b242dbee2491cdd98180ee7d0a4fe8.png',
+          height: 175,
+          width: 800,
+        },
+        larger: {
+          download:
+            'http://localhost:3000/images/plone-foundation.png/@@images/image-1000-39bec9ae81852eede0f930c9aced869b.png',
+          height: 219,
+          width: 1000,
+        },
+        mini: {
+          download:
+            'http://localhost:3000/images/plone-foundation.png/@@images/image-200-010a606b0d76b6a6e089e8ba466dedca.png',
+          height: 43,
+          width: 200,
+        },
+        preview: {
+          download:
+            'http://localhost:3000/images/plone-foundation.png/@@images/image-400-1766720795b7f683a5d9c9672b9fb259.png',
+          height: 87,
+          width: 400,
+        },
+        teaser: {
+          download:
+            'http://localhost:3000/images/plone-foundation.png/@@images/image-600-85dc73d6512c05dad7f2ad0bab8c256d.png',
+          height: 131,
+          width: 600,
+        },
+        thumb: {
+          download:
+            'http://localhost:3000/images/plone-foundation.png/@@images/image-128-b60c381eeb9c02111b3b8d5b82e4fcd8.png',
+          height: 28,
+          width: 128,
+        },
+        tile: {
+          download:
+            'http://localhost:3000/images/plone-foundation.png/@@images/image-64-b45e38d323633ae920af93e7e7e24656.png',
+          height: 14,
+          width: 64,
+        },
+      });
+    });
+    test('createScaledSrc', () => {
+      expect(
+        srcSetDefaultOptionsVolto.createScaledSrc(
+          srcSetDefaultOptionsVolto.preprocessSrc(testData.contentDataSample1),
+          'large',
+          testData.contentDataSample1.scales.large,
+        ),
+      ).toEqual({
+        url:
+          '/images/plone-foundation.png/@@images/image-800-00b242dbee2491cdd98180ee7d0a4fe8.png',
+        width: 800,
+      });
+    });
+    test('createNoDefaultScaleSrc', () => {
+      expect(
+        srcSetDefaultOptionsVolto.createNoDefaultScaleSrc(
+          testData.contentDataSample1,
+        ),
+      ).toBe(
+        '/images/plone-foundation.png/@@images/image-2000-9d895f5dd2600938c123550e14965f08.png',
+      );
+    });
+  });
+  describe('stringSrc', () => {
+    test('test', () => {
+      expect(processors.blockDataSrc.test(testData.stringSample1)).toEqual(
+        false,
+      );
+      expect(processors.contentDataSrc.test(testData.stringSample1)).toEqual(
+        false,
+      );
+      expect(processors.stringSrc.test(testData.stringSample1)).toEqual(true);
+    });
+    test('isLocal', () => {
+      expect(srcSetDefaultOptionsVolto.isLocal(testData.stringSample1)).toBe(
+        true,
+      );
+      expect(processors.stringSrc.isLocal('http://foo.bar/image.png')).toBe(
+        false,
+      );
+    });
+    test('preprocessSrc', () => {
+      expect(
+        srcSetDefaultOptionsVolto.preprocessSrc(testData.stringSample1),
+      ).toBe('');
+    });
+    test('getScalesFromProps', () => {
+      expect(
+        srcSetDefaultOptionsVolto.getScalesFromProps({
+          src: testData.stringSample1,
+          scales: '{DATA}',
+        }),
+      ).toEqual('{DATA}');
+    });
+    test('createScaledSrc', () => {
+      expect(
+        srcSetDefaultOptionsVolto.createScaledSrc(
+          srcSetDefaultOptionsVolto.preprocessSrc(testData.stringSample1),
+          'large',
+          800,
+        ),
+      ).toEqual({
+        url: '/@@images/image/large',
+        width: 800,
+      });
+    });
+    test('createNoDefaultScaleSrc', () => {
+      expect(
+        srcSetDefaultOptionsVolto.createNoDefaultScaleSrc(
+          testData.stringSample1,
+        ),
+      ).toBe(undefined);
+    });
+  });
+  describe('missingSrc', () => {
+    test('test', () => {
+      expect(processors.blockDataSrc.test(undefined)).toEqual(false);
+      expect(processors.contentDataSrc.test(undefined)).toEqual(false);
+      expect(processors.stringSrc.test(undefined)).toEqual(false);
+      expect(processors.missingSrc.test(undefined)).toEqual(true);
+    });
+    test('isLocal', () => {
+      expect(srcSetDefaultOptionsVolto.isLocal(undefined)).toBe(false);
+    });
+    test('preprocessSrc', () => {
+      expect(srcSetDefaultOptionsVolto.preprocessSrc(undefined)).toBe(
+        undefined,
+      );
+    });
+    test('getScalesFromProps', () => {
+      expect(
+        srcSetDefaultOptionsVolto.getScalesFromProps({
+          src: undefined,
+          scales: '{DATA}',
+        }),
+      ).toEqual('{DATA}');
+    });
+    test('createNoDefaultScaleSrc', () => {
+      expect(
+        srcSetDefaultOptionsVolto.createNoDefaultScaleSrc(
+          testData.missingSample1,
+        ),
+      ).toBe(undefined);
+    });
+  });
+});

--- a/src/components/ImageLoader/srcSetDefaultOptionsVolto.test.jsx
+++ b/src/components/ImageLoader/srcSetDefaultOptionsVolto.test.jsx
@@ -3,6 +3,7 @@ import * as processors from './srcSetDefaultOptionsVolto';
 import * as testData from './test-data';
 
 jest.mock('@plone/volto/helpers', () => {
+  const original = jest.requireActual('@plone/volto/helpers');
   return {
     __esModule: true,
     flattenToAppURL: jest.fn((url) =>
@@ -99,7 +100,8 @@ describe('srcSetDefaultOptionsVolto', () => {
           srcSetDefaultOptionsVolto.createScaledSrc(
             srcSetDefaultOptionsVolto.preprocessSrc(blockDataSample),
             'large',
-            blockDataSample.image_scales.image[0].scales.large,
+            blockDataSample.image_scales[blockDataSample.image_field][0].scales
+              .large,
           ),
         ).toEqual(result);
       };

--- a/src/components/ImageLoader/srcSetDefaultOptionsVolto.test.jsx
+++ b/src/components/ImageLoader/srcSetDefaultOptionsVolto.test.jsx
@@ -3,7 +3,6 @@ import * as processors from './srcSetDefaultOptionsVolto';
 import * as testData from './test-data';
 
 jest.mock('@plone/volto/helpers', () => {
-  const original = jest.requireActual('@plone/volto/helpers');
   return {
     __esModule: true,
     flattenToAppURL: jest.fn((url) =>

--- a/src/components/ImageLoader/srcSetDefaultOptionsVolto.test.jsx
+++ b/src/components/ImageLoader/srcSetDefaultOptionsVolto.test.jsx
@@ -30,6 +30,9 @@ describe('srcSetDefaultOptionsVolto', () => {
       expect(srcSetDefaultOptionsVolto.isLocal(testData.blockDataSample2)).toBe(
         true,
       );
+      expect(srcSetDefaultOptionsVolto.isLocal(testData.blockDataSample3)).toBe(
+        true,
+      );
       expect(
         processors.blockDataSrc.isLocal({ url: 'http://foo.bar/image.png' }),
       ).toBe(false);
@@ -92,6 +95,61 @@ describe('srcSetDefaultOptionsVolto', () => {
           width: 64,
         },
       });
+      expect(
+        srcSetDefaultOptionsVolto.getScalesFromProps({
+          src: testData.blockDataSample3,
+          scales: 'ANYTHING',
+        }),
+      ).toEqual({
+        icon: {
+          download:
+            '@@images/preview_image-32-55bf93d1a340ed478f81be2833a71993.jpeg',
+          height: 32,
+          width: 32,
+        },
+        large: {
+          download:
+            '@@images/preview_image-800-eb3aebd2b90ad5b03fcbdcef0be0beb5.jpeg',
+          height: 800,
+          width: 800,
+        },
+        larger: {
+          download:
+            '@@images/preview_image-1000-aa0b59eca1a9b588993187796d29e491.jpeg',
+          height: 1000,
+          width: 1000,
+        },
+        mini: {
+          download:
+            '@@images/preview_image-200-87345416346beb71801c3e0e6274125c.jpeg',
+          height: 200,
+          width: 200,
+        },
+        preview: {
+          download:
+            '@@images/preview_image-400-2df9d934007070e332dcb58d0d42be2f.jpeg',
+          height: 400,
+          width: 400,
+        },
+        teaser: {
+          download:
+            '@@images/preview_image-600-84157b40fce66bd541a0876f5534c125.jpeg',
+          height: 600,
+          width: 600,
+        },
+        thumb: {
+          download:
+            '@@images/preview_image-128-b0e482c9def76f77ef514904bc0a567b.jpeg',
+          height: 128,
+          width: 128,
+        },
+        tile: {
+          download:
+            '@@images/preview_image-64-0c3b9155a1112aaaf093e722f926fcb3.jpeg',
+          height: 64,
+          width: 64,
+        },
+      });
     });
     describe('createScaledSrc', () => {
       const testCreateScaledSrc = (blockDataSample, result) => () => {
@@ -120,6 +178,14 @@ describe('srcSetDefaultOptionsVolto', () => {
           width: 800,
         }),
       );
+      test(
+        'blockDataSample3 teaser',
+        testCreateScaledSrc(testData.blockDataSample3, {
+          url:
+            '/example/teaser-block/image/@@images/preview_image-800-eb3aebd2b90ad5b03fcbdcef0be0beb5.jpeg',
+          width: 800,
+        }),
+      );
     });
     test('createNoDefaultScaleSrc', () => {
       expect(
@@ -128,6 +194,13 @@ describe('srcSetDefaultOptionsVolto', () => {
         ),
       ).toBe(
         '/example/image-2/@@images/image-1126-7bb80db0a452739fa96a97d3c6517495.jpeg',
+      );
+      expect(
+        srcSetDefaultOptionsVolto.createNoDefaultScaleSrc(
+          testData.blockDataSample3,
+        ),
+      ).toBe(
+        '/example/teaser-block/image/@@images/preview_image-1126-1a01db87b603934db947bb1d72a06ed8.jpeg',
       );
     });
   });

--- a/src/components/ImageLoader/test-data.js
+++ b/src/components/ImageLoader/test-data.js
@@ -141,6 +141,85 @@ export const blockDataSample2 = {
   url: 'http://localhost:3000/example/image-2',
 };
 
+export const blockDataSample3 = {
+  // Teaser from object browser has @id instead of url
+  '@id': 'http://localhost:3000/example/teaser-block/image',
+  '@type': 'Document',
+  Description:
+    'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.',
+  Title: 'Headline H2',
+  effective: '2022-12-15T13:28:23+00:00',
+  getObjSize: '929.3 KB',
+  getRemoteUrl: null,
+  hasPreviewImage: true,
+  head_title: null,
+  image_field: 'preview_image',
+  image_scales: {
+    preview_image: [
+      {
+        'content-type': 'image/jpeg',
+        download:
+          '@@images/preview_image-1126-1a01db87b603934db947bb1d72a06ed8.jpeg',
+        filename: 'bfs-image-2.jpg',
+        height: 1126,
+        scales: {
+          icon: {
+            download:
+              '@@images/preview_image-32-55bf93d1a340ed478f81be2833a71993.jpeg',
+            height: 32,
+            width: 32,
+          },
+          large: {
+            download:
+              '@@images/preview_image-800-eb3aebd2b90ad5b03fcbdcef0be0beb5.jpeg',
+            height: 800,
+            width: 800,
+          },
+          larger: {
+            download:
+              '@@images/preview_image-1000-aa0b59eca1a9b588993187796d29e491.jpeg',
+            height: 1000,
+            width: 1000,
+          },
+          mini: {
+            download:
+              '@@images/preview_image-200-87345416346beb71801c3e0e6274125c.jpeg',
+            height: 200,
+            width: 200,
+          },
+          preview: {
+            download:
+              '@@images/preview_image-400-2df9d934007070e332dcb58d0d42be2f.jpeg',
+            height: 400,
+            width: 400,
+          },
+          teaser: {
+            download:
+              '@@images/preview_image-600-84157b40fce66bd541a0876f5534c125.jpeg',
+            height: 600,
+            width: 600,
+          },
+          thumb: {
+            download:
+              '@@images/preview_image-128-b0e482c9def76f77ef514904bc0a567b.jpeg',
+            height: 128,
+            width: 128,
+          },
+          tile: {
+            download:
+              '@@images/preview_image-64-0c3b9155a1112aaaf093e722f926fcb3.jpeg',
+            height: 64,
+            width: 64,
+          },
+        },
+        size: 951578,
+        width: 1126,
+      },
+    ],
+  },
+  mime_type: 'text/plain',
+  title: 'Headline H2',
+};
 export const contentDataSample1 = {
   'content-type': 'image/png',
   download:

--- a/src/components/ImageLoader/test-data.js
+++ b/src/components/ImageLoader/test-data.js
@@ -1,0 +1,214 @@
+export const blockDataSample1 = {
+  '@type': 'image',
+  align: 'center',
+  credit: {},
+  id: 'ad43f059-fab9-4b7b-b49f-d4ec1fb6e3fc',
+  image_scales: {
+    image: [
+      {
+        'content-type': 'image/jpeg',
+        download: '@@images/image-1126-7bb80db0a452739fa96a97d3c6517495.jpeg',
+        filename: 'image-light.jpg',
+        height: 633,
+        scales: {
+          icon: {
+            download: '@@images/image-32-d5575b5e0795407436104a16e18ebd41.jpeg',
+            height: 17,
+            width: 32,
+          },
+          large: {
+            download:
+              '@@images/image-800-9c8a61153197fca732c86aa1f2091cb3.jpeg',
+            height: 449,
+            width: 800,
+          },
+          larger: {
+            download:
+              '@@images/image-1000-36afc44f7c991c35735f3338e76bc0a7.jpeg',
+            height: 562,
+            width: 1000,
+          },
+          mini: {
+            download:
+              '@@images/image-200-6f2dd5c028b4fbf2c975d98f42077678.jpeg',
+            height: 112,
+            width: 200,
+          },
+          preview: {
+            download:
+              '@@images/image-400-4abbad67754c69a7af7a1b91d78e680e.jpeg',
+            height: 224,
+            width: 400,
+          },
+          teaser: {
+            download:
+              '@@images/image-600-705867124c8790a0fc7d4c799e506c2e.jpeg',
+            height: 337,
+            width: 600,
+          },
+          thumb: {
+            download:
+              '@@images/image-128-eebe3707668d4cd3752626c026191ca0.jpeg',
+            height: 71,
+            width: 128,
+          },
+          tile: {
+            download: '@@images/image-64-0ea29ecf0ed3720e590d849dcbda5834.jpeg',
+            height: 35,
+            width: 64,
+          },
+        },
+        size: 475285,
+        width: 1126,
+      },
+    ],
+  },
+  size: 'l',
+  title: 'Headline H2 ',
+  url: '/example/image-2',
+};
+
+export const blockDataSample2 = {
+  '@type': 'image',
+  align: 'center',
+  credit: {},
+  id: 'ad43f059-fab9-4b7b-b49f-d4ec1fb6e3fc',
+  image_scales: {
+    image: [
+      {
+        'content-type': 'image/jpeg',
+        download: '@@images/image-1126-7bb80db0a452739fa96a97d3c6517495.jpeg',
+        filename: 'image-light.jpg',
+        height: 633,
+        scales: {
+          icon: {
+            download: '@@images/image-32-d5575b5e0795407436104a16e18ebd41.jpeg',
+            height: 17,
+            width: 32,
+          },
+          large: {
+            download:
+              '@@images/image-800-9c8a61153197fca732c86aa1f2091cb3.jpeg',
+            height: 449,
+            width: 800,
+          },
+          larger: {
+            download:
+              '@@images/image-1000-36afc44f7c991c35735f3338e76bc0a7.jpeg',
+            height: 562,
+            width: 1000,
+          },
+          mini: {
+            download:
+              '@@images/image-200-6f2dd5c028b4fbf2c975d98f42077678.jpeg',
+            height: 112,
+            width: 200,
+          },
+          preview: {
+            download:
+              '@@images/image-400-4abbad67754c69a7af7a1b91d78e680e.jpeg',
+            height: 224,
+            width: 400,
+          },
+          teaser: {
+            download:
+              '@@images/image-600-705867124c8790a0fc7d4c799e506c2e.jpeg',
+            height: 337,
+            width: 600,
+          },
+          thumb: {
+            download:
+              '@@images/image-128-eebe3707668d4cd3752626c026191ca0.jpeg',
+            height: 71,
+            width: 128,
+          },
+          tile: {
+            download: '@@images/image-64-0ea29ecf0ed3720e590d849dcbda5834.jpeg',
+            height: 35,
+            width: 64,
+          },
+        },
+        size: 475285,
+        width: 1126,
+      },
+    ],
+  },
+  size: 'l',
+  title: 'Headline H2 ',
+  // an url that MUST be flattened, and we test for it
+  url: 'http://localhost:3000/example/image-2',
+};
+
+export const contentDataSample1 = {
+  'content-type': 'image/png',
+  download:
+    'http://localhost:3000/images/plone-foundation.png/@@images/image-2000-9d895f5dd2600938c123550e14965f08.png',
+  filename: null,
+  height: 439,
+  scales: {
+    great: {
+      download:
+        'http://localhost:3000/images/plone-foundation.png/@@images/image-1200-79d8298ba97bbcac8957f2313a4f8739.png',
+      height: 263,
+      width: 1200,
+    },
+    huge: {
+      download:
+        'http://localhost:3000/images/plone-foundation.png/@@images/image-1600-36844277b711713c66c7c77f6eafa2bf.png',
+      height: 351,
+      width: 1600,
+    },
+    icon: {
+      download:
+        'http://localhost:3000/images/plone-foundation.png/@@images/image-32-471419cba465f6bf008e71a2a6597a40.png',
+      height: 7,
+      width: 32,
+    },
+    large: {
+      download:
+        'http://localhost:3000/images/plone-foundation.png/@@images/image-800-00b242dbee2491cdd98180ee7d0a4fe8.png',
+      height: 175,
+      width: 800,
+    },
+    larger: {
+      download:
+        'http://localhost:3000/images/plone-foundation.png/@@images/image-1000-39bec9ae81852eede0f930c9aced869b.png',
+      height: 219,
+      width: 1000,
+    },
+    mini: {
+      download:
+        'http://localhost:3000/images/plone-foundation.png/@@images/image-200-010a606b0d76b6a6e089e8ba466dedca.png',
+      height: 43,
+      width: 200,
+    },
+    preview: {
+      download:
+        'http://localhost:3000/images/plone-foundation.png/@@images/image-400-1766720795b7f683a5d9c9672b9fb259.png',
+      height: 87,
+      width: 400,
+    },
+    teaser: {
+      download:
+        'http://localhost:3000/images/plone-foundation.png/@@images/image-600-85dc73d6512c05dad7f2ad0bab8c256d.png',
+      height: 131,
+      width: 600,
+    },
+    thumb: {
+      download:
+        'http://localhost:3000/images/plone-foundation.png/@@images/image-128-b60c381eeb9c02111b3b8d5b82e4fcd8.png',
+      height: 28,
+      width: 128,
+    },
+    tile: {
+      download:
+        'http://localhost:3000/images/plone-foundation.png/@@images/image-64-b45e38d323633ae920af93e7e7e24656.png',
+      height: 14,
+      width: 64,
+    },
+  },
+  size: 50737,
+  width: 2000,
+};
+
+export const stringSample1 = 'http://localhost:3000/@@images/image/huge';

--- a/src/components/ImageLoader/test-data.js
+++ b/src/components/ImageLoader/test-data.js
@@ -220,6 +220,78 @@ export const blockDataSample3 = {
   mime_type: 'text/plain',
   title: 'Headline H2',
 };
+
+export const blockDataSample4 = {
+  '@type': 'image',
+  align: 'center',
+  credit: {},
+  id: 'ad43f059-fab9-4b7b-b49f-d4ec1fb6e3fc',
+  // missing image_field
+  image_scales: {
+    image: [
+      {
+        'content-type': 'image/jpeg',
+        download: '@@images/image-1126-7bb80db0a452739fa96a97d3c6517495.jpeg',
+        filename: 'image-light.jpg',
+        height: 633,
+        scales: {
+          icon: {
+            download: '@@images/image-32-d5575b5e0795407436104a16e18ebd41.jpeg',
+            height: 17,
+            width: 32,
+          },
+          large: {
+            download:
+              '@@images/image-800-9c8a61153197fca732c86aa1f2091cb3.jpeg',
+            height: 449,
+            width: 800,
+          },
+          larger: {
+            download:
+              '@@images/image-1000-36afc44f7c991c35735f3338e76bc0a7.jpeg',
+            height: 562,
+            width: 1000,
+          },
+          mini: {
+            download:
+              '@@images/image-200-6f2dd5c028b4fbf2c975d98f42077678.jpeg',
+            height: 112,
+            width: 200,
+          },
+          preview: {
+            download:
+              '@@images/image-400-4abbad67754c69a7af7a1b91d78e680e.jpeg',
+            height: 224,
+            width: 400,
+          },
+          teaser: {
+            download:
+              '@@images/image-600-705867124c8790a0fc7d4c799e506c2e.jpeg',
+            height: 337,
+            width: 600,
+          },
+          thumb: {
+            download:
+              '@@images/image-128-eebe3707668d4cd3752626c026191ca0.jpeg',
+            height: 71,
+            width: 128,
+          },
+          tile: {
+            download: '@@images/image-64-0ea29ecf0ed3720e590d849dcbda5834.jpeg',
+            height: 35,
+            width: 64,
+          },
+        },
+        size: 475285,
+        width: 1126,
+      },
+    ],
+  },
+  size: 'l',
+  title: 'Headline H2 ',
+  url: '/example/image-2',
+};
+
 export const contentDataSample1 = {
   'content-type': 'image/png',
   download:

--- a/src/components/ImageLoader/test-data.js
+++ b/src/components/ImageLoader/test-data.js
@@ -3,6 +3,7 @@ export const blockDataSample1 = {
   align: 'center',
   credit: {},
   id: 'ad43f059-fab9-4b7b-b49f-d4ec1fb6e3fc',
+  image_field: 'image',
   image_scales: {
     image: [
       {
@@ -73,6 +74,7 @@ export const blockDataSample2 = {
   align: 'center',
   credit: {},
   id: 'ad43f059-fab9-4b7b-b49f-d4ec1fb6e3fc',
+  image_field: 'image',
   image_scales: {
     image: [
       {

--- a/src/customizations/volto/components/manage/Blocks/Image/Edit.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Image/Edit.jsx
@@ -84,20 +84,7 @@ class ImageEdit extends Component {
    */
   render() {
     const { block, data, onChangeBlock } = this.props;
-    const Img = config.getComponent('Image').component;
-    // Note defaultScale will be deprecated from Img component
-    // Since we have srcset, it has no importance other than
-    // the original image should never be used.
-    const defaultScale =
-      data.align === 'full'
-        ? 'fullscreen'
-        : data.size === 'l'
-        ? 'huge'
-        : data.size === 'm'
-        ? 'preview'
-        : data.size === 's'
-        ? 'mini'
-        : 'huge';
+    const Image = config.getComponent('Image').component;
 
     const dataAdapter = config.getComponent({
       name: 'dataAdapter',
@@ -132,12 +119,10 @@ class ImageEdit extends Component {
               },
             )}
           >
-            <Img
+            <Image
               loading="lazy"
-              src={data.url}
+              src={data}
               alt={data.alt || ''}
-              defaultScale={defaultScale}
-              scales={data.image_scales?.image?.[0]?.scales}
               blurhash={data.image_scales?.image?.[0]?.blurhash}
             />
             <Caption

--- a/src/customizations/volto/components/manage/Blocks/Image/View.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Image/View.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 import { flattenToAppURL } from '@plone/volto/helpers';
-import { UniversalLink } from '@plone/volto/components';
+import { MaybeWrap, UniversalLink } from '@plone/volto/components';
 
 import config from '@plone/volto/registry';
 import Caption from '@kitconcept/volto-image-block/components/Caption/Caption';
@@ -18,7 +18,7 @@ import Caption from '@kitconcept/volto-image-block/components/Caption/Caption';
  * @class View
  * @extends Component
  */
-const ImageBlockView = ({ data, detached, className }) => {
+const ImageBlockView = ({ data, detached, className, isEditMode }) => {
   let href;
   if (data.href?.length > 0) {
     if (typeof data.href === 'object') {
@@ -29,83 +29,60 @@ const ImageBlockView = ({ data, detached, className }) => {
     }
   }
 
+  const Image = config.getComponent('Image').component;
+
   return (
     <div className={cx('block image align', data.align, className)}>
       {data.url && (
         <>
-          {(() => {
-            const Img = config.getComponent('Image').component;
-            // Note defaultScale will be deprecated from Img component
-            // Since we have srcset, it has no importance other than
-            // the original image should never be used.
-            const defaultScale =
-              data.align === 'full'
-                ? 'fullscreen'
-                : data.size === 'l'
-                ? 'huge'
-                : data.size === 'm'
-                ? 'preview'
-                : data.size === 's'
-                ? 'mini'
-                : 'huge';
-            const image = (
-              <figure
-                className={cx(
-                  'figure',
-                  {
-                    center: !Boolean(data.align),
-                    detached,
-                  },
-                  data.align,
-                  {
-                    // START CUSTOMIZATION
-                    // 'full-width': data.align === 'full',
-                    // END CUSTOMIZATION
-                    large: data.size === 'l',
-                    medium: data.size === 'm' || !data.size,
-                    small: data.size === 's',
-                  },
-                )}
-              >
-                <Img
-                  loading="lazy"
-                  src={data.url}
-                  width="1440"
-                  height="810"
-                  alt={data.alt || ''}
-                  defaultScale={defaultScale}
-                  scales={data.image_scales?.image?.[0]?.scales}
-                  blurhash={data.image_scales?.image?.[0]?.blurhash}
-                />
-                <Caption
-                  title={data.title}
-                  description={data.description}
-                  credit={data.credit?.data}
-                  downloadFilename={data.title}
-                  downloadHref={
-                    data.allow_image_download &&
-                    `${flattenToAppURL(data.url)}/${
-                      data.image_scales?.image[0].scales?.fullscreen
-                        ?.download || data.image_scales?.image[0].download
-                    }`
-                  }
-                />
-              </figure>
-            );
-
-            if (href) {
-              return (
-                <UniversalLink
-                  openLinkInNewTab={data.openLinkInNewTab}
-                  href={href}
-                >
-                  {image}
-                </UniversalLink>
-              );
-            } else {
-              return image;
-            }
-          })()}
+          <MaybeWrap
+            condition={href && !isEditMode}
+            as={UniversalLink}
+            href={href}
+            openLinkInNewTab={data.openLinkInNewTab}
+            target={data.openLinkInNewTab ? '_blank' : null}
+          >
+            <figure
+              className={cx(
+                'figure',
+                {
+                  center: !Boolean(data.align),
+                  detached,
+                },
+                data.align,
+                {
+                  // START CUSTOMIZATION
+                  // 'full-width': data.align === 'full',
+                  // END CUSTOMIZATION
+                  large: data.size === 'l',
+                  medium: data.size === 'm' || !data.size,
+                  small: data.size === 's',
+                },
+              )}
+            >
+              <Image
+                loading="lazy"
+                src={data}
+                width="1440"
+                height="810"
+                alt={data.alt || ''}
+                blurhash={data.image_scales?.image?.[0]?.blurhash}
+              />
+              <Caption
+                title={data.title}
+                description={data.description}
+                credit={data.credit?.data}
+                downloadFilename={data.title}
+                downloadHref={
+                  data.allow_image_download &&
+                  `${flattenToAppURL(data.url)}/${
+                    data.image_scales?.image[0].scales?.fullscreen?.download ||
+                    data.image_scales?.image[0].download
+                  }`
+                }
+              />
+            </figure>
+          </MaybeWrap>
         </>
       )}
     </div>

--- a/src/customizations/volto/components/theme/View/ImageView.jsx
+++ b/src/customizations/volto/components/theme/View/ImageView.jsx
@@ -1,0 +1,92 @@
+/**
+ * Image view component.
+ * @module components/theme/View/ImageView
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Container } from 'semantic-ui-react';
+
+import { flattenToAppURL } from '@plone/volto/helpers';
+
+// BEGIN CUSTOMIZATION
+import config from '@plone/volto/registry';
+import Caption from '@kitconcept/volto-image-block/components/Caption/Caption';
+
+// END CUSTOMIZATION
+
+/**
+ * Image view component class.
+ * @function ImageView
+ * @params {object} content Content object.
+ * @returns {string} Markup of the component.
+ */
+const ImageView = ({ content }) => {
+  const Image = config.getComponent('Image').component;
+  return (
+    <Container className="view-wrapper">
+      {/* BEGIN CUSTOMIZATION */}
+      <h1 className="documentFirstHeading">{content.title}</h1>
+      {content?.image?.download && (
+        <figure>
+          <Image
+            width={content.image?.width}
+            height={content.image?.height}
+            alt={content.alt_tag}
+            src={content.image}
+            blurhash={content.blurhash}
+            blurhashOptions={{
+              // override default width 100%
+              style: {},
+            }}
+            style={{ maxWidth: '100%', height: 'auto' }}
+          />
+          <Caption
+            title={content.title}
+            description={content.description}
+            credit={content.credit?.data}
+            shows_people={content.shows_people}
+            downloadFilename={content.title}
+            downloadHref={
+              content.allow_image_download &&
+              flattenToAppURL(
+                content.image.scales.fullscreen?.download ||
+                  content.image.download,
+              )
+            }
+          />
+        </figure>
+      )}
+      {/* END CUSTOMIZATION */}
+    </Container>
+  );
+};
+
+/**
+ * Property types.
+ * @property {Object} propTypes Property types.
+ * @static
+ */
+ImageView.propTypes = {
+  content: PropTypes.shape({
+    title: PropTypes.string,
+    description: PropTypes.string,
+    image: PropTypes.shape({
+      scales: PropTypes.shape({
+        preview: PropTypes.shape({
+          download: PropTypes.string,
+        }),
+      }),
+    }),
+    // BEGIN CUSTOMIZATION
+    allow_image_download: PropTypes.bool,
+    shows_people: PropTypes.bool,
+    credit: PropTypes.shape({
+      data: PropTypes.string,
+    }),
+    alt_tag: PropTypes.string,
+    // END CUSTOMIZATION
+  }).isRequired,
+};
+
+export default ImageView;

--- a/src/customizations/volto/components/theme/View/ImageView.jsx
+++ b/src/customizations/volto/components/theme/View/ImageView.jsx
@@ -32,7 +32,7 @@ const ImageView = ({ content }) => {
           <Image
             width={content.image?.width}
             height={content.image?.height}
-            alt={content.alt_tag}
+            alt={content.alt_tag || ''}
             src={content.image}
             blurhash={content.blurhash}
             blurhashOptions={{


### PR DESCRIPTION
Supported use cases to use data from the back-end:

- block image
- content image

Also continued to be supported:

- static scale data that can be defined from the config

As a consequence, `config.scrSetOptions` is not needed for these use cases and it just works out of the box.

Originally requested in
https://github.com/kitconcept/volto-light-theme/issues/40