### PR TITLE
Fix image render on upload, the item is not being passed

### DIFF
--- a/src/components/Blocks/Image/adapter.js
+++ b/src/components/Blocks/Image/adapter.js
@@ -46,7 +46,7 @@ export const ImageBlockDataAdapter = ({
       credit: { data: item?.credit },
       description: item?.Description,
       title: item?.Title,
-      image_scales: item?.image_scales || {},
+      image_scales: item?.image_scales,
     };
   }
   onChangeBlock(block, dataSaved);

--- a/src/components/ImageWidget/ImageWidget.jsx
+++ b/src/components/ImageWidget/ImageWidget.jsx
@@ -65,7 +65,7 @@ const ImageWidget = (props) => {
   useEffect(() => {
     if (loading && requestLoaded && uploading) {
       setUploading(false);
-      onChange(id, urlUploaded);
+      onChange(id, urlUploaded, content);
     }
   }, [id, urlUploaded, requestLoaded, loading, uploading, onChange]);
 

--- a/src/components/ImageWidget/ImageWidget.jsx
+++ b/src/components/ImageWidget/ImageWidget.jsx
@@ -65,7 +65,7 @@ const ImageWidget = (props) => {
   useEffect(() => {
     if (loading && requestLoaded && uploading) {
       setUploading(false);
-      onChange(id, urlUploaded, content);
+      onChange(id, urlUploaded);
     }
   }, [id, urlUploaded, requestLoaded, loading, uploading, onChange]);
 

--- a/src/customizations/volto/components/manage/Blocks/Image/Edit.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Image/Edit.jsx
@@ -117,7 +117,12 @@ class ImageEdit extends Component {
           >
             <Image
               loading="lazy"
-              src={data}
+              // TODO: Improve this, please
+              src={
+                data.image_scales
+                  ? data
+                  : `${flattenToAppURL(data.url)}/@@images/image`
+              }
               alt={data.alt || ''}
               blurhash={data.image_scales?.image?.[0]?.blurhash}
             />


### PR DESCRIPTION
@davisagli we have to meet and talk about the image situation. We end up with multiple representations of an image in catalog, in the content and in the serialized data somehow and support all of them in the components is becoming a nightmare.

So far:
* we save the image in the `url` in block `data` as string
* we inject the image_scales in the block on serialization,
* we have the full image serialized from the content image
* when we upload an image inline in a block as well.