### PR TITLE
Support block data with missing image_scales, after image upload

### DIFF
--- a/news/16.bugfix
+++ b/news/16.bugfix
@@ -1,0 +1,1 @@
+Support block data with missing image_scales, after image upload @reebalazs

--- a/src/components/ImageLoader/srcSetDefaultOptionsVolto.jsx
+++ b/src/components/ImageLoader/srcSetDefaultOptionsVolto.jsx
@@ -28,6 +28,27 @@ export const blockDataSrc = {
     ),
 };
 
+// Acquire server data for a block, no scale info, no download attribute
+// We encounter this case when an image just has been uploaded
+export const blockDataNoScalesSrc = {
+  test: (src) => typeof src?.image_scales === 'object',
+  isLocal: (src) => isInternalURL(blockDataPrefixGet(src)),
+  preprocessSrc: (src) => ({
+    ...src,
+    __cache: {
+      prefix: flattenToAppURL(
+        blockDataPrefixGet(src)
+          .replace(/\/@@images\/image.*$/, '')
+          .replace(/\/$/, ''),
+      ),
+    },
+  }),
+  getScalesFromProps: ({ src, scales }) => {},
+  createScaledSrc: (src, scaleName, scaleData) => ({}),
+  createNoDefaultScaleSrc: (src) =>
+    flattenToAppURL(`${blockDataPrefixGet(src)}/@@images/image`),
+};
+
 // Acquire server data for an image instance
 export const contentDataSrc = {
   test: (src) => typeof src?.scales === 'object',
@@ -70,6 +91,8 @@ export const missingSrc = {
 const getProcessor = (src) =>
   blockDataSrc.test(src)
     ? blockDataSrc
+    : blockDataNoScalesSrc.test(src)
+    ? blockDataNoScalesSrc
     : contentDataSrc.test(src)
     ? contentDataSrc
     : stringSrc.test(src)

--- a/src/components/ImageLoader/srcSetDefaultOptionsVolto.test.jsx
+++ b/src/components/ImageLoader/srcSetDefaultOptionsVolto.test.jsx
@@ -272,6 +272,94 @@ describe('srcSetDefaultOptionsVolto', () => {
       );
     });
   });
+  describe('blockDataNoScalesSrc', () => {
+    test('test', () => {
+      expect(
+        processors.blockDataSrc.test(testData.blockDataSampleNoScales1),
+      ).toEqual(false);
+      expect(
+        processors.blockDataSrc.test(testData.blockDataSampleNoScales2),
+      ).toEqual(false);
+      expect(
+        processors.blockDataNoScalesSrc.test(testData.blockDataNoScalesSample1),
+      ).toEqual(true);
+      expect(
+        processors.blockDataNoScalesSrc.test(testData.blockDataNoScalesSample2),
+      ).toEqual(true);
+    });
+    test('isLocal', () => {
+      expect(
+        srcSetDefaultOptionsVolto.isLocal(testData.blockDataNoScalesSample1),
+      ).toBe(true);
+      expect(
+        srcSetDefaultOptionsVolto.isLocal(testData.blockDataNoScalesSample2),
+      ).toBe(true);
+      expect(
+        processors.blockDataNoScalesSrc.isLocal({
+          url: 'http://foo.bar/image.png',
+        }),
+      ).toBe(false);
+    });
+    test('preprocessSrc', () => {
+      expect(
+        srcSetDefaultOptionsVolto.preprocessSrc(
+          testData.blockDataNoScalesSample1,
+        ),
+      ).toEqual({
+        ...testData.blockDataNoScalesSample1,
+        __cache: {
+          prefix: '/image1234.jpg',
+        },
+      });
+      expect(
+        srcSetDefaultOptionsVolto.preprocessSrc(
+          testData.blockDataNoScalesSample2,
+        ),
+      ).toEqual({
+        ...testData.blockDataNoScalesSample2,
+        __cache: {
+          prefix: '/image1234.jpg',
+        },
+      });
+    });
+    test('getScalesFromProps', () => {
+      expect(
+        srcSetDefaultOptionsVolto.getScalesFromProps({
+          src: testData.blockDataNoScalesSample1,
+          scales: 'ANYTHING',
+        }),
+      ).toEqual(undefined);
+      expect(
+        srcSetDefaultOptionsVolto.getScalesFromProps({
+          src: testData.blockDataNoScalesSample2,
+          scales: 'ANYTHING',
+        }),
+      ).toEqual(undefined);
+    });
+    test('createScaledSrc', () => {
+      expect(
+        srcSetDefaultOptionsVolto.createScaledSrc(
+          srcSetDefaultOptionsVolto.preprocessSrc(
+            testData.blockDataNoScalesSample1,
+          ),
+          'large',
+          800,
+        ),
+      ).toEqual({});
+    });
+    test('createNoDefaultScaleSrc', () => {
+      expect(
+        srcSetDefaultOptionsVolto.createNoDefaultScaleSrc(
+          testData.blockDataNoScalesSample1,
+        ),
+      ).toBe('/image1234.jpg/@@images/image');
+      expect(
+        srcSetDefaultOptionsVolto.createNoDefaultScaleSrc(
+          testData.blockDataNoScalesSample2,
+        ),
+      ).toBe('/image1234.jpg/@@images/image');
+    });
+  });
   describe('contentDataSrc', () => {
     test('test', () => {
       expect(processors.blockDataSrc.test(testData.contentDataSample1)).toEqual(

--- a/src/components/ImageLoader/test-data.js
+++ b/src/components/ImageLoader/test-data.js
@@ -292,6 +292,27 @@ export const blockDataSample4 = {
   url: '/example/image-2',
 };
 
+export const blockDataNoScalesSample1 = {
+  '@type': 'image',
+  url: 'http://localhost:3000/image1234.jpg',
+  // empty image_scales, missing image_field
+  image_scales: {},
+  align: 'center',
+  size: 'l',
+  styles: { 'size:noprefix': 'large' },
+};
+
+export const blockDataNoScalesSample2 = {
+  '@type': 'image',
+  // Teaser from object browser has @id instead of url
+  '@id': 'http://localhost:3000/image1234.jpg',
+  // empty image_scales, missing image_field
+  image_scales: {},
+  align: 'center',
+  size: 'l',
+  styles: { 'size:noprefix': 'large' },
+};
+
 export const contentDataSample1 = {
   'content-type': 'image/png',
   download:


### PR DESCRIPTION
image_scales={}, missing default_field.

This happens right after an image is uploaded. Although, this is probably a bug on the back-end, because at this time the scales are already available, so it would be expected to also have the image_scales in the payload.

Fall back to showing the original image, `@@image/image` in this case.